### PR TITLE
fix: don't log by default when using api

### DIFF
--- a/tcp-proxy-cli.js
+++ b/tcp-proxy-cli.js
@@ -35,7 +35,7 @@ argv
     .parse(process.argv);
 
 var options = Object.assign(argv, {
-    quiet: argv.q,
+    quiet: argv.q === true,
     rejectUnauthorized: argv.rejectUnauthorized !== "false",
     identUsers: argv.identUsers === '' ? [] : argv.identUsers.split(','),
     allowedIps: argv.allowedIPs === '' ? [] : argv.allowedIPs.split(',')

--- a/tcp-proxy.js
+++ b/tcp-proxy.js
@@ -46,9 +46,9 @@ function TcpProxy(proxyPort, serviceHost, servicePort, options) {
     this.proxySockets = {};
     if (this.options.identUsers.length !== 0) {
         this.users = this.options.identUsers;
-        this.log('Only allow these users: '.concat(this.users.join(', ')));
+        this.log('Will only allow these users: '.concat(this.users.join(', ')));
     } else {
-        this.log('Allow all users');
+        this.log('Will allow all users');
     }
     if (this.options.allowedIPs.length !== 0) {
         this.allowedIPs = this.options.allowedIPs;
@@ -58,7 +58,7 @@ function TcpProxy(proxyPort, serviceHost, servicePort, options) {
 
 TcpProxy.prototype.parseOptions = function(options) {
     return Object.assign({
-        quiet: false,
+        quiet: true,
         pfx: require.resolve('./cert.pfx'),
         passphrase: 'abcd',
         rejectUnauthorized: true,


### PR DESCRIPTION
fix #28

Also I changed the log messages to "*Will* allow all users"/"*Will* only allow these users:".  "Allow all users" by itself is a bit ambiguous