### PR TITLE
add custom tls server options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { Socket } from 'net';
-import { TLSSocket } from 'tls';
+import { TLSSocket ,TlsOptions} from 'tls';
 
 // Name or IP address of service host(s); if this is a list, performs round-robin load balancing
 type ServiceHost = string | string[];
@@ -41,6 +41,8 @@ interface TcpProxyOptions {
     identUsers: string[];
     // List of allowed IPs
     allowedIPs: string[];
+    // Custom tls server options
+    customTlsOptions: TlsOptions;
     serviceHostSelected: (proxySocket: Socket | TLSSocket, i: number) => number;
     upstream: (context: UpstreamContext, data: Buffer) => Buffer;
     downstream: (context: DownstreamContext, data: Buffer) => Buffer;

--- a/tcp-proxy.js
+++ b/tcp-proxy.js
@@ -70,7 +70,7 @@ TcpProxy.prototype.parseOptions = function(options) {
 TcpProxy.prototype.createListener = function() {
     var self = this;
     if (self.options.tls) {
-        self.server = tls.createServer(self.proxyTlsOptions, function(socket) {
+        self.server = tls.createServer(self.options.customTlsOptions || self.proxyTlsOptions, function(socket) {
             self.handleClientConnection(socket);
         });
     } else {


### PR DESCRIPTION
# Sumary
It would be nice to have the opportunity of setting custom options for TLS server. 
Please consider this PR. It's my first open-source contribution and it's simple, but solved a huge problem in my implementation of node-tcp-proxy. Maybe this pr will help others as well.
# What it does
- add "customTlsOptions" to node-tcp-proxy.createServer options.
- add type for "customTlsOptions"
- add a condition that replaces proxyTlsOptions for customTlsOptions if customTlsOptions is passed